### PR TITLE
explicitly use ConsistentRead: true for Dynamo DB scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.1]
+### Added
+use `ConsistentRead: true` for Dynamo DB scanning params
+
 ## [1.3.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fjandin/config-man",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Config manager",
   "main": "index.js",
   "author": "René Bischoff <rene.bischoff@gmail.com> (https://github.com/fjandin)",

--- a/src/lib/config/dynamodb.ts
+++ b/src/lib/config/dynamodb.ts
@@ -8,7 +8,7 @@ export default function getConfigAwsDynamo(
     if (options.sync) {
         throw new Error('This type does not support sync')
     }
-    const scanParams = {TableName: options.tableName}
+    const scanParams = {TableName: options.tableName, ConsistentRead: true}
     const awsConfig = {region: options.region}
 
     AWS.config.update(awsConfig)


### PR DESCRIPTION
I was unlucky to get the issue where Dynamo DB items were not immediately available for `scan` operation. We inserted 3 Dynamo DB records and depending on AWS internal optimisation just inserted elements were available for some `scan` calls and were not available for other `scan` calls (exactly the same lambda call in the same region. as if we called `scan` few times). 

```
Jul 9 11:51:01 some_lambda_name [$LATEST]cd8d5814c8cd43a6817c49b68bee1216 error Error '077d75fb-d963-4025-800b-9e7c039b3aef' 'ConfigMan: invalid config
(pdf.certificate.s3.key) invalid type. Expected <string> got <undefined>
(pdf.certificate.secretmanager.name) invalid type. Expected <string> got <undefined>'
...
Jul 9 11:51:09 some_lambda_name [$LATEST]a96c5d9cf0fe46beafac440129957c83 error Error 'b2b85d8c-263c-45b2-81b6-c70e31b72d19' 'ConfigMan: invalid config
(pdf.certificate.s3.bucket) invalid type. Expected <string> got <undefined>
(pdf.certificate.s3.key) invalid type. Expected <string> got <undefined>
(pdf.certificate.secretmanager.name) invalid type. Expected <string> got <undefined>'
...
Jul 9 11:52:47 some_lambda_name [$LATEST]cd8d5814c8cd43a6817c49b68bee1216 error Error 'a4edd3fb-b6b2-44b1-9432-63de4416d861' 'ConfigMan: invalid config
(pdf.certificate.s3.key) invalid type. Expected <string> got <undefined>
(pdf.certificate.secretmanager.name) invalid type. Expected <string> got <undefined>'
...
```

Having said that we inserted all 3 DB records at the same time and we have seen them in AWS UI. But because of some reasons 2 of them (`pdf.certificate.secretmanager.name` and `pdf.certificate.s3.key`) were not available for dynamodb client even after 30 mins where `pdf.certificate.s3.bucket` was available and unavailable again (see log example above) depending on something on AWS side.

Here is AWS documentation regarding `scan`
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html

>ConsistentRead
A Boolean value that determines the read consistency model during the scan:
>
>If ConsistentRead is false, then the data returned from Scan might not contain the results from other recently completed write operations (PutItem, UpdateItem, or DeleteItem).
>
>If ConsistentRead is true, then all of the write operations that completed before the Scan began are guaranteed to be contained in the Scan response.
>
>The default setting for ConsistentRead is false.

Unfortunately AWS does not clarify anything regarding how long 
>Scan might not contain the results from other recently completed write operations

as well as what "recently completed " means exactly (few seconds? few minutes? few hours?). We inserted items during business hours where Lambdas actively read Dynamo DB table (consider it as a highload). I suppose AWS may use some caches/optimisations which do not update data immediately even in the same region where table data is actively used by clients.