### PR TITLE
Thorwessel/update flat dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.3]
+### Changed
+ - Upgrade flat dependency to 5.0.2
+
 ## [1.3.2]
 ### Changed
  - Upgrade flat package to latest (patch)

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "build": "rm -rf dist; tsc -p tsconfig.build.json; cp package.json ./dist; cp README.md ./dist; cp LICENSE ./dist; cp SECURITY.md ./dist;"
   },
   "dependencies": {
-    "flat": "^5.0.0"
+    "flat": "^5.0.2"
   },
   "devDependencies": {
-    "@types/flat": "^5.0.0",
+    "@types/flat": "^5.0.1",
     "@types/jest": "^25.1.2",
     "@types/node": "^12.6.2",
     "@typescript-eslint/eslint-plugin": "^2.19.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fjandin/config-man",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Config manager",
   "main": "index.js",
   "author": "René Bischoff <rene.bischoff@gmail.com> (https://github.com/fjandin)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,7 +375,7 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/flat@^5.0.0":
+"@types/flat@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/flat/-/flat-5.0.1.tgz#9d703bbfb59ad9ec9ce376bdeb93a0f85da27059"
   integrity sha512-ykRODHi9G9exJdTZvQggsqCUtB7jqiwLHcXCjNMb7zgWx6Lc2bydIUYBG1+It6VXZVFaeROv6HqPjDCAsoPG3w==
@@ -1495,7 +1495,7 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
-flat@^5.0.0:
+flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==


### PR DESCRIPTION
Hey, long time user, first time contributer. I use this library everyday and absolutely loooove the author!


This PR should update the package.json for Snyk not to fail with:
```
Issues with no direct upgrade or patch:
  ✗ Prototype Pollution [Medium Severity][https://snyk.io/vuln/SNYK-JS-FLAT-596927] in flat@5.0.0
    introduced by @fjandin/config-man@1.3.2 > flat@5.0.0
  This issue was fixed in versions: 5.0.2, 4.1.2, 3.0.1, 2.0.2, 5.0.2, 1.6.2
```

Unfortunately I still experience Snyk is complaining after Janne's update.