### PR TITLE
fix misprint in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.1]
+### Added
+use `ConsistentRead: true` for Dynamo DB scanning params
+
 ## [1.3.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-=======
+## [1.3.4]
+### Changed
+ - fix misprint in README for JSON config
+ 
 ## [1.3.3]
 ### Changed
  - Upgrade flat package to latest (patch)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ configMan.init({
     configs: [
         {type: configMan.ConfigType.DEFAULT},
         {type: configMan.ConfigType.DYNAMODB, tableName: 'Configuration-Table', region: 'eu-west-1'},
-        {type: configMan.ConfigType.JSON, filepath: path.resolve('config.json')},
+        {type: configMan.ConfigType.JSON, filePath: path.resolve('config.json')},
         {type: configMan.ConfigType.ARG, prefix: 'CM_'},
         {type: configMan.ConfigType.ENV, prefix: 'CM_}
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fjandin/config-man",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Config manager",
   "main": "index.js",
   "author": "René Bischoff <rene.bischoff@gmail.com> (https://github.com/fjandin)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fjandin/config-man",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "description": "Config manager",
   "main": "index.js",
   "author": "René Bischoff <rene.bischoff@gmail.com> (https://github.com/fjandin)",

--- a/src/lib/config/dynamodb.ts
+++ b/src/lib/config/dynamodb.ts
@@ -8,7 +8,7 @@ export default function getConfigAwsDynamo(
     if (options.sync) {
         throw new Error('This type does not support sync')
     }
-    const scanParams = {TableName: options.tableName}
+    const scanParams = {TableName: options.tableName, ConsistentRead: true}
     const awsConfig = {region: options.region}
 
     AWS.config.update(awsConfig)


### PR DESCRIPTION
need to fix misprint in README. JSON config should have `filePath` instead of `filepath`