### PR TITLE
feat(aws-sdk): upgrade aws-sdk to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.0]
+
+### Added
+- Upgraded from aws-sdk v2 to client specific v3 libraries (@aws-sdk/client-dynamodb & @aws-sdk/client-secrets-manager)
+
 ## [1.7.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fjandin/config-man",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Config manager",
   "main": "index.js",
   "author": "René Bischoff <rene.bischoff@gmail.com> (https://github.com/fjandin)",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "peer": "yarn add --peer --frozen-lockfile aws-sdk@^2.895.0",
+    "peer": "yarn add --peer --frozen-lockfile @aws-sdk/client-secrets-manager@^3.379.0 @aws-sdk/client-dynamodb@^3.379.0",
     "lint": "eslint src --ext .ts,.js",
     "lint:fix": "eslint src --ext .ts,.js --fix",
     "typecheck": "tsc --noEmit",
@@ -46,6 +46,7 @@
     "typescript": "^4.2.4"
   },
   "peerDependencies": {
-    "aws-sdk": "^2.895.0"
+    "@aws-sdk/client-dynamodb": "^3.379.0",
+    "@aws-sdk/client-secrets-manager": "^3.379.0"
   }
 }


### PR DESCRIPTION
This PR upgrades to `aws-sdk` v3 from v2. The upgrade involves using client specific libraries for secrets manager and dynamo db. This is required when using lambdas on Node 18 as `aws-sdk` is no longer available in the runtime.

Tested via unit tests & manual test via `yarn link`.